### PR TITLE
Remove explicit poetry version from build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: snok/install-poetry@v1
-        with:
-          version: 1.8.5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"


### PR DESCRIPTION
Plugin is now available for poetry v2 so no need to explicitly reference v1 in build.yaml